### PR TITLE
Add baseline security hardening for static donation pages

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,5 @@
+Contact: mailto:security@vonsteinkirch.com
+Expires: 2027-01-01T00:00:00.000Z
+Preferred-Languages: en
+Canonical: https://donations.vonsteinkirch.com/.well-known/security.txt
+Policy: https://donations.vonsteinkirch.com/

--- a/404.html
+++ b/404.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <title>page not found</title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ a static, single-page donation site with **stripe** (card/fiat) and **cryptocurr
 
 - all user-facing strings live in `config/text.js`: page title, header, tagline, section titles, button labels, and copy-button text.
 
+## security
+
+- `index.html` and `404.html` include a strict Content Security Policy and referrer policy to reduce script-injection and data-leakage risks.
+- `.well-known/security.txt` provides a standardized disclosure contact for responsible vulnerability reporting.
+
 ## development
 
 **local server:** `make server` (default port 8033) or `python3 -m http.server 8033`.

--- a/index.html
+++ b/index.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; object-src 'none'; base-uri 'self'; form-action 'self'; frame-ancestors 'none'; upgrade-insecure-requests">
+  <meta name="referrer" content="strict-origin-when-cross-origin">
   <title></title>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
### Motivation

- Improve the default security posture for the static donation site by reducing script injection and sensitive data leakage risk in browsers. 
- Provide a canonical contact for vulnerability disclosure so security researchers have a standard reporting channel. 

### Description

- Add a strict `Content-Security-Policy` and `Referrer-Policy` meta tags to `index.html` to limit script, resource, and referrer behavior. 
- Add the same CSP and referrer hardening to `404.html` to ensure consistent protection across pages. 
- Add `.well-known/security.txt` with contact, expiration, and canonical metadata for responsible disclosure. 
- Document the new security measures in `README.md` under a new `## security` section. 

### Testing

- Ran `npm run check` (which executes `eslint` and `node test/dom-test.js`) and it completed successfully. 
- The JSDOM-based DOM tests in `test/dom-test.js` passed and reported `DOM tests passed.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac63e6e1a4832ea2f8b46d39441994)